### PR TITLE
Setup github action to test build

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,27 @@
+name: Swift
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        swift: ["5", "5.7"]
+        
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: swift-actions/setup-swift@v1.26.0
+      with:
+        swift-version: ${{ matrix.swift }}
+    - uses: actions/checkout@v4
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v


### PR DESCRIPTION
This workflow should build and test on the latest Swift 5 release as well as 5.7 on both MacOS and Linux when pull requests are created targeting master or there is a push to master.